### PR TITLE
Improved footer.

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -2,8 +2,9 @@ body{background:transparent url('../img/bg.jpg');font-family:'Titillium Web',san
 body .container header,body footer .container{margin-top:4em;padding:2em 0;}
 body .container article h2{font-size:48px;line-height:48px;color:#c95555;font-weight:200;text-transform:uppercase;margin-bottom:25px;}body .container article h2.newsletter{margin-top:40px;}
 small{color:#999;}
+body footer .container{margin-top:2em;padding:1em;}
 body footer a:hover{text-decoration:none;}
-.navbar nav{background-color:#2b2f35;}
+header.navbar,footer{background-color:#2b2f35;}
 #map-canvas{width:100%;height:300px;border:1px solid #ccc;}
 .dl-horizontal dt,.dl-horizontal dd{padding:3px 0;}
 .dl-horizontal dt{width:60px;}

--- a/public/css/custom.less
+++ b/public/css/custom.less
@@ -6,7 +6,7 @@
 
 @pastel_red: #FF6961;
 
-body{
+body {
   background: transparent url('../img/bg.jpg');
   font-family: 'Titillium Web', sans-serif;
   font-size: 1em;
@@ -34,11 +34,19 @@ small {
   color: #999;
 }
 
-body footer a:hover {
-  text-decoration: none;
+body footer {
+  .container {
+    margin-top: 2em;
+    padding: 1em;
+  }
+
+  a:hover {
+    text-decoration: none;
+  }
 }
 
-.navbar nav {
+header.navbar,
+footer {
   background-color: #2b2f35;
 }
 

--- a/views/base.haml
+++ b/views/base.haml
@@ -24,19 +24,16 @@
         .row-fluid= yield
     %footer
       .container
-        %p.pull-left.muted
-          %a{ href: "https://github.com/gotar/TRUG.git"}
-            %img{src: 'img/icons/Github.png'}
-            Kod źródłowy
-          \- zapraszam do udziału w tworzeniu strony.
-        %p.pull-right
+        %div.pull-left.muted
           %a{href: 'https://groups.google.com/forum/?hl=pl&fromgroups#!forum/trug-pl'}
             %img{src: 'img/icons/groups.png'}
           %a{href: 'https://plus.google.com/u/0/115366219080630998906/posts'}
             %img{src: 'img/icons/Google.png'}
-        .clearfix
-        %a.pull-left{href: 'http://shellycloud.com'}
-          %img{src: 'img/shelly-cloud-banner.png'}
+          %a{ href: "https://github.com/gotar/TRUG.git"}
+            %img{src: 'img/icons/Github.png'}
+        %div.pull-right
+          %a.pull-left{href: 'http://shellycloud.com'}
+            %img{src: 'img/shelly-cloud-banner.png'}
 
     %script{ src: "http://code.jquery.com/jquery.js"}
     %script{ src: "js/bootstrap.min.js"}


### PR DESCRIPTION
- Removed information about source code (leaved only icon),
- Moved g+ and google groups icon to the left (before github icon),
- Moved shelly logo to the right (on the same level as icons at
  the left)
- Added backgroud color (the same as in header navbar),
- Changed margin and padding

![zaznaczenie_005](https://f.cloud.github.com/assets/619324/1925604/5c9051ca-7e34-11e3-85ff-263c9e92b1dd.png)
